### PR TITLE
README.md: JSON linting for 'secrets.json' and 'settings.json'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Create a file named `secrets.json` in the same directory as the `main.py` file. 
     "browserid": "your_browser_id_here",
     "lang": "en",
     "ndus": "your_ndus_token_here",
-    "ndut_fmt": "your_ndut_fmt_token_here",
+    "ndut_fmt": "your_ndut_fmt_token_here"
   }
 }
 
@@ -74,11 +74,11 @@ Create a file named `settings.json` in the same directory as the `main.py` file.
   "directories": {
     "sourcedir": "source_directory_here",
     "remotedir": "remote_terabox_directory_here",
-    "uploadeddir": "uploaded_files_directory_here",
+    "uploadeddir": "uploaded_files_directory_here"
   },
   "files": {
     "movefiles": "false or true",
-    "deletesource": "false or true",
+    "deletesource": "false or true"
   },
   "encryption": {
     "enabled": "true or false",

--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ if not os.path.exists("secrets.json"):
     fmt.error("auth", '        "browserid": "your browserid",')
     fmt.error("auth", '        "lang": "your lang (NOT REQUIRED)",')
     fmt.error("auth", '        "ndus": "your ndus token",')
-    fmt.error("auth", '        "ndut_fmt": "your ndut_fmt token",')
+    fmt.error("auth", '        "ndut_fmt": "your ndut_fmt token"')
     fmt.error("auth", '    }')
     fmt.error("auth", "}")
     exit()


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/[...]/dnigamer/TeraboxUploaderCLI/main.py", line 79, in <module>
    secrets = json.load(f)
              ^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 293, in load
    return loads(fp.read(),
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 10 column 3 (char 498)
```