### PR TITLE
main.py: Fixed f~type strings problems

### DIFF
--- a/main.py
+++ b/main.py
@@ -441,7 +441,7 @@ for file in files:
         for i in range(num_chunks):
             start = i * chunk_size
             end = min((i + 1) * chunk_size, len(content))
-            chunk_filename = f"{os.path.join(temp_directory, f"{file['name']}.part")}{i:03d}"
+            chunk_filename = os.path.join(temp_directory, f"{file['name']}.part{i:03d}")
             with open(chunk_filename, 'wb') as chunk_file:
                 chunk_file.write(content[start:end])
                 chunk_file.close()
@@ -478,7 +478,7 @@ for file in files:
                 errors = True
                 continue
             fmt.info("split upload", f"Piece {pieces.index(pi) + 1} of {len(pieces)} uploaded successfully.")
-        fmt.success("split upload", f"All pieces uploaded successfully.")
+        fmt.success("split upload", "All pieces uploaded successfully.")
     else:
         fmt.info("upload", f"Uploading file {file['name']}...")
         uploadhash = upload_file(pieces[0], uploadid, md5dict[0])


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/home/[...]/dnigamer/TeraboxUploaderCLI/main.py", line 79, in <module>
    secrets = json.load(f)
              ^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 293, in load
    return loads(fp.read(),
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 10 column 3 (char 498)
```
