### PR TITLE
main.py: Don't continue upload looping if the login session has expired.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import math
 import os
+import sys
 import json
 import subprocess
 import hashlib
@@ -201,7 +202,7 @@ def precreate_file(filename: str, md5json: str) -> str:
             fmt.error("precreate", "File precreate failed.")
             if json.loads(preresponse.text)["errmsg"] == 'need verify':
                 fmt.error("precreate", "The login session has expired. Please login again and refresh the credentials.")
-                return "fail"
+                return "session_expired"
             fmt.error("precreate", f"ERROR: More information: {json.loads(preresponse.text)}")
             return "fail"
     except Exception as e:
@@ -436,6 +437,8 @@ for file in files:
     if uploadid == "fail":
         errors = True
         continue
+    elif uploadid == "session_expired":
+        sys.exit()
     fmt.success("precreate", f"Precreate for upload ID \"{uploadid}\" successful.")
     cloudpath = remoteloc + "/" + file['name']
 

--- a/main.py
+++ b/main.py
@@ -438,7 +438,8 @@ for file in files:
         errors = True
         continue
     elif uploadid == "session_expired":
-        sys.exit()
+        errors = True
+        break
     fmt.success("precreate", f"Precreate for upload ID \"{uploadid}\" successful.")
     cloudpath = remoteloc + "/" + file['name']
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import math
 import os
-import sys
 import json
 import subprocess
 import hashlib
@@ -202,7 +201,7 @@ def precreate_file(filename: str, md5json: str) -> str:
             fmt.error("precreate", "File precreate failed.")
             if json.loads(preresponse.text)["errmsg"] == 'need verify':
                 fmt.error("precreate", "The login session has expired. Please login again and refresh the credentials.")
-                return "session_expired"
+                return "session"
             fmt.error("precreate", f"ERROR: More information: {json.loads(preresponse.text)}")
             return "fail"
     except Exception as e:
@@ -437,7 +436,7 @@ for file in files:
     if uploadid == "fail":
         errors = True
         continue
-    elif uploadid == "session_expired":
+    elif uploadid == "session":
         errors = True
         break
     fmt.success("precreate", f"Precreate for upload ID \"{uploadid}\" successful.")


### PR DESCRIPTION
This fixes a problem I had when I was uploading 50 1GB files, and on the 8th one the session had expired.  I didn't see this condition _(distracted)_ until it was on the 35th file.  During that time, the loop had racked up a lot of time from performing the _(unused)_ MD5 calculations.

In summation, it should stop the loop immediately when there is a "need verify" condition.
